### PR TITLE
update gradle version and fix dependencies to work with latest gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,12 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
         maven {
-            url 'http://dl.bintray.com/jetbrains/intellij-plugin-service'
+            url 'https://dl.bintray.com/jetbrains/intellij-plugin-service'
         }
 
     }
     dependencies {
-        classpath "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.3.12"
+        classpath "org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.7.2"
         classpath 'net.researchgate:gradle-release:2.6.0' // https://github.com/researchgate/gradle-release
     }
 }
@@ -40,13 +40,13 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-    compile 'com.contrastsecurity:contrast-sdk-java:2.9'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    implementation 'com.contrastsecurity:contrast-sdk-java:2.9'
     // https://mvnrepository.com/artifact/com.github.lgooddatepicker/LGoodDatePicker
-    compile group: 'com.github.lgooddatepicker', name: 'LGoodDatePicker', version: '10.3.1'
-    compile 'org.unbescape:unbescape:1.1.5.RELEASE'
-    compile 'com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2'
-    compile group: 'org.apache.commons', name: 'commons-text', version: '1.6'
+    implementation group: 'com.github.lgooddatepicker', name: 'LGoodDatePicker', version: '10.3.1'
+    implementation 'org.unbescape:unbescape:1.1.5.RELEASE'
+    implementation 'com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.6'
 }
 
 apply plugin: 'org.jetbrains.intellij'


### PR DESCRIPTION
This fixes the gradle build so that pulling this down with the latest gradle, the buildPlugin command should work.

Steps to verify:
Clean your gradle cache (I had to manually go into .gradle file to do this properly just gradle clean didn't work)

Run the buildPlugin command. You should get a successful build.