### PR TITLE
TS-17935-Enable-dependabot-for-Intellij-Plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle" 
+    directory: "/" 
+    target-branch: master
+    schedule:
+      interval: "daily"
+      time: "07:00"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,10 @@ updates:
     schedule:
       interval: "daily"
       time: "07:00"
+    labels:
+      - "dependencies"
     open-pull-requests-limit: 5
+    reviewers:
+          - "aliaandersen"
+          - "bryanateoan"
+          - "MiguelUrrutiaSoler"


### PR DESCRIPTION
Ticket:https://contrast.atlassian.net/browse/TS-17935

Dependabot configuration was added and checked that all dependencies where in the same place cause partial gradle support for dependabot.

How to test: 
Run in the pipeline the dependabot.yml file
