### PR TITLE
TS-17930 Remove uses of deprecated APIs in IntelliJ plugin - Beta

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 8
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '8'
+        java-version: '17'
         distribution: 'temurin'
     - name: Build with Gradle
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.9.0"
-        classpath 'net.researchgate:gradle-release:2.6.0' // https://github.com/researchgate/gradle-release
+        classpath 'net.researchgate:gradle-release:3.0.2' // https://github.com/researchgate/gradle-release
     }
 }
 
@@ -64,7 +64,7 @@ release {
     failOnCommitNeeded = false
     failOnUnversionedFiles = false
     git {
-         requireBranch = ''
+         requireBranch.set('')
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 
     }
     dependencies {
-        classpath "org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.7.2"
+        classpath "org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.9.0"
         classpath 'net.researchgate:gradle-release:2.6.0' // https://github.com/researchgate/gradle-release
     }
 }
@@ -33,7 +33,7 @@ version project.properties['version']
 
 apply plugin: 'java'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 17
 
 repositories {
     mavenCentral()
@@ -47,6 +47,7 @@ dependencies {
     implementation 'org.unbescape:unbescape:1.1.6.RELEASE'
     implementation 'com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2'
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+    implementation 'org.apache.commons:commons-text:1.10.0'
 }
 
 apply plugin: 'org.jetbrains.intellij'
@@ -55,8 +56,8 @@ apply plugin: 'java'
 apply plugin: 'net.researchgate.release'
 
 intellij {
-    version 'IC-172.4343.14' //IntelliJ IDEA IC-172.4343.14 dependency; for a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
-    intellij.updateSinceUntilBuild false //Disables updating since-build attribute in plugin.xml
+    version.set('IC-222.4345.14') //The lastest version of intellji. For older version of intellji use version 2.10 of the plugin
+    plugins = ['java']
 }
 
 release {
@@ -68,3 +69,4 @@ release {
 }
 
 beforeReleaseBuild.dependsOn buildPlugin
+targetCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/com/contrastsecurity/config/ContrastFilterPersistentStateComponent.java
+++ b/src/main/java/com/contrastsecurity/config/ContrastFilterPersistentStateComponent.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import org.jetbrains.annotations.Nullable;
 
@@ -79,7 +80,7 @@ public class ContrastFilterPersistentStateComponent implements PersistentStateCo
 
     @Nullable
     public static ContrastFilterPersistentStateComponent getInstance(Project project) {
-        return ServiceManager.getService(project, ContrastFilterPersistentStateComponent.class);
+        return project.getService(ContrastFilterPersistentStateComponent.class);
     }
 
     public String getSelectedApplicationName() {

--- a/src/main/java/com/contrastsecurity/config/ContrastPersistentStateComponent.java
+++ b/src/main/java/com/contrastsecurity/config/ContrastPersistentStateComponent.java
@@ -15,11 +15,14 @@
 package com.contrastsecurity.config;
 
 import com.contrastsecurity.core.Constants;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.project.impl.ProjectManagerImpl;
 import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.apache.tools.ant.Project;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
@@ -75,7 +78,7 @@ public class ContrastPersistentStateComponent implements PersistentStateComponen
 
     @Nullable
     public static ContrastPersistentStateComponent getInstance() {
-        return ServiceManager.getService(ContrastPersistentStateComponent.class);
+        return ApplicationManager.getApplication().getService(ContrastPersistentStateComponent.class);
     }
 
     public String getSelectedOrganizationName() {

--- a/src/main/java/com/contrastsecurity/config/ContrastUtil.java
+++ b/src/main/java/com/contrastsecurity/config/ContrastUtil.java
@@ -36,11 +36,12 @@ import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
 import com.contrastsecurity.sdk.UserAgentProduct;
 import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.components.ComponentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.net.HttpConfigurable;
 import com.intellij.util.proxy.CommonProxy;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/com/contrastsecurity/config/ContrastUtil.java
+++ b/src/main/java/com/contrastsecurity/config/ContrastUtil.java
@@ -35,8 +35,6 @@ import com.contrastsecurity.models.Trace;
 import com.contrastsecurity.models.Traces;
 import com.contrastsecurity.sdk.ContrastSDK;
 import com.contrastsecurity.sdk.UserAgentProduct;
-import com.intellij.openapi.application.ApplicationInfo;
-import com.intellij.openapi.components.ComponentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.net.HttpConfigurable;
 import com.intellij.util.proxy.CommonProxy;

--- a/src/main/java/com/contrastsecurity/ui/com/contrastsecurity/ui/toolwindow/ContrastToolWindowFactory.java
+++ b/src/main/java/com/contrastsecurity/ui/com/contrastsecurity/ui/toolwindow/ContrastToolWindowFactory.java
@@ -72,7 +72,7 @@ import com.intellij.ui.content.ContentFactory;
 import com.intellij.util.messages.MessageBus;
 import icons.ContrastPluginIcons;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.unbescape.html.HtmlEscape;
 
@@ -229,7 +229,7 @@ public class ContrastToolWindowFactory implements ToolWindowFactory {
                                     if (typeName.contains(delimiter)) {
                                         String filePath = ContrastUtil.getFilePath(project.getName(), typeName, delimiter);
                                         if (filePath != null) {
-                                            VirtualFile virtualFile = project.getBaseDir().findFileByRelativePath(filePath);
+                                            VirtualFile virtualFile = project.getProjectFile().findFileByRelativePath(filePath);
                                             if (virtualFile != null) {
                                                 fileFound = true;
                                                 if (lineNumber != null) {
@@ -240,7 +240,7 @@ public class ContrastToolWindowFactory implements ToolWindowFactory {
                                             }
                                         }
                                     } else {
-                                        PsiFile[] psiFiles = FilenameIndex.getFilesByName(project, typeName, globalSearchScope);
+                                        PsiFile[] psiFiles = FilenameIndex.getVirtualFilesByName(typeName, globalSearchScope).toArray(PsiFile[]::new);
                                         if (psiFiles.length > 0) {
                                             fileFound = true;
                                             for (PsiFile psiFile : psiFiles) {
@@ -486,7 +486,7 @@ public class ContrastToolWindowFactory implements ToolWindowFactory {
 
     public void process(ToolWindow toolWindow) {
 
-        ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
+        ContentFactory contentFactory = ContentFactory.getInstance();
         Content content = contentFactory.createContent(contrastToolWindowContent, "", false);
         toolWindow.getContentManager().addContent(content);
 

--- a/src/main/java/com/contrastsecurity/ui/com/contrastsecurity/ui/toolwindow/EventTreeCellRenderer.java
+++ b/src/main/java/com/contrastsecurity/ui/com/contrastsecurity/ui/toolwindow/EventTreeCellRenderer.java
@@ -23,7 +23,7 @@ import com.contrastsecurity.core.extended.Line;
 import com.contrastsecurity.models.EventItem;
 import com.intellij.ui.JBColor;
 import com.intellij.util.ui.JBUI;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import javax.swing.BoxLayout;
 import javax.swing.JLabel;

--- a/src/main/java/com/contrastsecurity/ui/settings/ContrastSearchableConfigurable.java
+++ b/src/main/java/com/contrastsecurity/ui/settings/ContrastSearchableConfigurable.java
@@ -17,6 +17,8 @@ package com.contrastsecurity.ui.settings;
 import com.contrastsecurity.config.ContrastPersistentStateComponent;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SearchableConfigurable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,7 +47,13 @@ public class ContrastSearchableConfigurable implements SearchableConfigurable {
     @Nullable
     @Override
     public JComponent createComponent() {
-        contrastSearchableConfigurableGUI = new ContrastSearchableConfigurableGUI();
+        try {
+            contrastSearchableConfigurableGUI = new ContrastSearchableConfigurableGUI();
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        } catch (TimeoutException e) {
+            throw new RuntimeException(e);
+        }
         return contrastSearchableConfigurableGUI.getContrastSettingsPanel();
     }
 

--- a/src/main/java/com/contrastsecurity/ui/settings/ContrastSearchableConfigurableGUI.java
+++ b/src/main/java/com/contrastsecurity/ui/settings/ContrastSearchableConfigurableGUI.java
@@ -20,19 +20,19 @@ import com.contrastsecurity.config.ContrastPersistentStateComponent;
 import com.contrastsecurity.config.ContrastUtil;
 import com.contrastsecurity.core.Constants;
 import com.contrastsecurity.exceptions.UnauthorizedException;
-import com.contrastsecurity.http.RequestConstants;
 import com.contrastsecurity.models.Organization;
 import com.contrastsecurity.models.Organizations;
 import com.contrastsecurity.sdk.ContrastSDK;
 import com.contrastsecurity.sdk.UserAgentProduct;
 import com.contrastsecurity.ui.com.contrastsecurity.ui.toolwindow.OrganizationTableModel;
 import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.actionSystem.DataKeys;
-import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.messages.MessageBus;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -69,10 +69,14 @@ public class ContrastSearchableConfigurableGUI {
     private Map<String, String> organizations = new HashMap<>();
     private OrganizationTableModel organizationTableModel = new OrganizationTableModel();
 
-    public ContrastSearchableConfigurableGUI() {
+    public ContrastSearchableConfigurableGUI() throws ExecutionException, TimeoutException {
 
-        DataContext dataContext = DataManager.getInstance().getDataContextFromFocus().getResult();
-        Project project = DataKeys.PROJECT.getData(dataContext);
+        DataContext dataContext = DataManager.getInstance().getDataContextFromFocusAsync().blockingGet(200);
+
+        assert dataContext != null;
+        Project project = CommonDataKeys.PROJECT.getData(dataContext);
+
+        assert project != null;
         contrastFilterPersistentStateComponent = ContrastFilterPersistentStateComponent.getInstance(project);
         contrastPersistentStateComponent = ContrastPersistentStateComponent.getInstance();
 

--- a/src/main/java/com/contrastsecurity/ui/settings/ContrastSearchableConfigurableGUI.java
+++ b/src/main/java/com/contrastsecurity/ui/settings/ContrastSearchableConfigurableGUI.java
@@ -26,6 +26,8 @@ import com.contrastsecurity.sdk.ContrastSDK;
 import com.contrastsecurity.sdk.UserAgentProduct;
 import com.contrastsecurity.ui.com.contrastsecurity.ui.toolwindow.OrganizationTableModel;
 import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.application.ApplicationManager;
@@ -74,7 +76,7 @@ public class ContrastSearchableConfigurableGUI {
         DataContext dataContext = DataManager.getInstance().getDataContextFromFocusAsync().blockingGet(200);
 
         assert dataContext != null;
-        Project project = CommonDataKeys.PROJECT.getData(dataContext);
+        Project project = dataContext.getData(CommonDataKeys.PROJECT);
 
         assert project != null;
         contrastFilterPersistentStateComponent = ContrastFilterPersistentStateComponent.getInstance(project);

--- a/src/main/java/icons/ContrastPluginIcons.java
+++ b/src/main/java/icons/ContrastPluginIcons.java
@@ -20,22 +20,22 @@ import javax.swing.*;
 
 public interface ContrastPluginIcons {
 
-    Icon CONTRAST_ICON = IconLoader.getIcon("/icons/contrastIcon.png");
-    Icon SETTINGS_ICON = IconLoader.getIcon("/icons/settings.png");
-    Icon SEVERITY_ICON_CRITICAL = IconLoader.getIcon("/icons/critical.png");
-    Icon SEVERITY_ICON_HIGH = IconLoader.getIcon("/icons/high.png");
-    Icon SEVERITY_ICON_MEDIUM = IconLoader.getIcon("/icons/medium.png");
-    Icon SEVERITY_ICON_LOW = IconLoader.getIcon("/icons/low.png");
-    Icon SEVERITY_ICON_NOTE = IconLoader.getIcon("/icons/note.png");
-    Icon EXTERNAL_LINK_ICON = IconLoader.getIcon("/icons/externalLink.png");
-    Icon DETAILS_ICON = IconLoader.getIcon("/icons/details.png");
-    Icon UNLICENSED_ICON = IconLoader.getIcon("/icons/unlicensed.png");
-    Icon REFRESH_ICON = IconLoader.getIcon("/icons/refresh_tab.png");
-    Icon FILTER_ICON = IconLoader.getIcon("/icons/filter.png");
-    Icon FIRST_PAGE_ICON = IconLoader.getIcon("/icons/first_page.png");
-    Icon LAST_PAGE_ICON = IconLoader.getIcon("/icons/last_page.png");
-    Icon PREVIOUS_PAGE_ICON = IconLoader.getIcon("/icons/previous_page.png");
-    Icon NEXT_PAGE_ICON = IconLoader.getIcon("/icons/next_page.png");
-    Icon TAG_ICON = IconLoader.getIcon("/icons/tag.png");
-    Icon REMOVE_ICON = IconLoader.getIcon("/icons/remove.png");
+    Icon CONTRAST_ICON = IconLoader.getIcon("/icons/contrastIcon.png", Icon.class);
+    Icon SETTINGS_ICON = IconLoader.getIcon("/icons/settings.png", Icon.class);
+    Icon SEVERITY_ICON_CRITICAL = IconLoader.getIcon("/icons/critical.png", Icon.class);
+    Icon SEVERITY_ICON_HIGH = IconLoader.getIcon("/icons/high.png", Icon.class);
+    Icon SEVERITY_ICON_MEDIUM = IconLoader.getIcon("/icons/medium.png", Icon.class);
+    Icon SEVERITY_ICON_LOW = IconLoader.getIcon("/icons/low.png", Icon.class);
+    Icon SEVERITY_ICON_NOTE = IconLoader.getIcon("/icons/note.png", Icon.class);
+    Icon EXTERNAL_LINK_ICON = IconLoader.getIcon("/icons/externalLink.png", Icon.class);
+    Icon DETAILS_ICON = IconLoader.getIcon("/icons/details.png", Icon.class);
+    Icon UNLICENSED_ICON = IconLoader.getIcon("/icons/unlicensed.png", Icon.class);
+    Icon REFRESH_ICON = IconLoader.getIcon("/icons/refresh_tab.png", Icon.class);
+    Icon FILTER_ICON = IconLoader.getIcon("/icons/filter.png", Icon.class);
+    Icon FIRST_PAGE_ICON = IconLoader.getIcon("/icons/first_page.png", Icon.class);
+    Icon LAST_PAGE_ICON = IconLoader.getIcon("/icons/last_page.png", Icon.class);
+    Icon PREVIOUS_PAGE_ICON = IconLoader.getIcon("/icons/previous_page.png", Icon.class);
+    Icon NEXT_PAGE_ICON = IconLoader.getIcon("/icons/next_page.png", Icon.class);
+    Icon TAG_ICON = IconLoader.getIcon("/icons/tag.png", Icon.class);
+    Icon REMOVE_ICON = IconLoader.getIcon("/icons/remove.png", Icon.class);
 }

--- a/src/main/java/icons/ContrastPluginIcons.java
+++ b/src/main/java/icons/ContrastPluginIcons.java
@@ -20,22 +20,22 @@ import javax.swing.*;
 
 public interface ContrastPluginIcons {
 
-    Icon CONTRAST_ICON = IconLoader.getIcon("/icons/contrastIcon.png", Icon.class);
-    Icon SETTINGS_ICON = IconLoader.getIcon("/icons/settings.png", Icon.class);
-    Icon SEVERITY_ICON_CRITICAL = IconLoader.getIcon("/icons/critical.png", Icon.class);
-    Icon SEVERITY_ICON_HIGH = IconLoader.getIcon("/icons/high.png", Icon.class);
-    Icon SEVERITY_ICON_MEDIUM = IconLoader.getIcon("/icons/medium.png", Icon.class);
-    Icon SEVERITY_ICON_LOW = IconLoader.getIcon("/icons/low.png", Icon.class);
-    Icon SEVERITY_ICON_NOTE = IconLoader.getIcon("/icons/note.png", Icon.class);
-    Icon EXTERNAL_LINK_ICON = IconLoader.getIcon("/icons/externalLink.png", Icon.class);
-    Icon DETAILS_ICON = IconLoader.getIcon("/icons/details.png", Icon.class);
-    Icon UNLICENSED_ICON = IconLoader.getIcon("/icons/unlicensed.png", Icon.class);
-    Icon REFRESH_ICON = IconLoader.getIcon("/icons/refresh_tab.png", Icon.class);
-    Icon FILTER_ICON = IconLoader.getIcon("/icons/filter.png", Icon.class);
-    Icon FIRST_PAGE_ICON = IconLoader.getIcon("/icons/first_page.png", Icon.class);
-    Icon LAST_PAGE_ICON = IconLoader.getIcon("/icons/last_page.png", Icon.class);
-    Icon PREVIOUS_PAGE_ICON = IconLoader.getIcon("/icons/previous_page.png", Icon.class);
-    Icon NEXT_PAGE_ICON = IconLoader.getIcon("/icons/next_page.png", Icon.class);
-    Icon TAG_ICON = IconLoader.getIcon("/icons/tag.png", Icon.class);
-    Icon REMOVE_ICON = IconLoader.getIcon("/icons/remove.png", Icon.class);
+    Icon CONTRAST_ICON = IconLoader.getIcon("/icons/contrastImageIcon.png", ContrastPluginIcons.class);
+    Icon SETTINGS_ICON = IconLoader.getIcon("/icons/settings.png", ContrastPluginIcons.class);
+    Icon SEVERITY_ICON_CRITICAL = IconLoader.getIcon("/icons/critical.png", ContrastPluginIcons.class);
+    Icon SEVERITY_ICON_HIGH = IconLoader.getIcon("/icons/high.png", ContrastPluginIcons.class);
+    Icon SEVERITY_ICON_MEDIUM = IconLoader.getIcon("/icons/medium.png", ContrastPluginIcons.class);
+    Icon SEVERITY_ICON_LOW = IconLoader.getIcon("/icons/low.png", ContrastPluginIcons.class);
+    Icon SEVERITY_ICON_NOTE = IconLoader.getIcon("/icons/note.png", ContrastPluginIcons.class);
+    Icon EXTERNAL_LINK_ICON = IconLoader.getIcon("/icons/externalLink.png", ContrastPluginIcons.class);
+    Icon DETAILS_ICON = IconLoader.getIcon("/icons/details.png", ContrastPluginIcons.class);
+    Icon UNLICENSED_ICON = IconLoader.getIcon("/icons/unlicensed.png", ContrastPluginIcons.class);
+    Icon REFRESH_ICON = IconLoader.getIcon("/icons/refresh_tab.png", ContrastPluginIcons.class);
+    Icon FILTER_ICON = IconLoader.getIcon("/icons/filter.png", ContrastPluginIcons.class);
+    Icon FIRST_PAGE_ICON = IconLoader.getIcon("/icons/first_page.png", ContrastPluginIcons.class);
+    Icon LAST_PAGE_ICON = IconLoader.getIcon("/icons/last_page.png", ContrastPluginIcons.class);
+    Icon PREVIOUS_PAGE_ICON = IconLoader.getIcon("/icons/previous_page.png", ContrastPluginIcons.class);
+    Icon NEXT_PAGE_ICON = IconLoader.getIcon("/icons/next_page.png", ContrastPluginIcons.class);
+    Icon TAG_ICON = IconLoader.getIcon("/icons/tag.png", ContrastPluginIcons.class);
+    Icon REMOVE_ICON = IconLoader.getIcon("/icons/remove.png", ContrastPluginIcons.class);
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
     <!--</change-notes>-->
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="171.0"/>
+    <idea-version since-build="222.4345.14"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->


### PR DESCRIPTION
### _Ticket_:
- [TS-17930](https://contrast.atlassian.net/browse/TS-17930)

### _Overview_:
- Updated the deprecated APIs to use the new modern versions. I also updated the plugin to run on java-17 and `gradle-intellij-plugin` 1.9 to gain access to the new APIs.

### _What Changed_:
- The plugin uses java-17 to build
-  updated to Gradle-Intellij-Plugin 1.9
- updated gradle-release to latest version
- Updated all APIs called out here to the new one: https://plugins.jetbrains.com/plugin/10335-contrast/versions/stable


### _How To Test_:
- run the `runIde` Gradle command
 <img width="796" alt="Screen Shot 2022-10-26 at 4 18 00 PM" src="https://user-images.githubusercontent.com/104797527/198128999-4c2024f8-c3bd-4fad-ab3d-06e03dcc5c35.png">

- open any java project in the ide that appears
- Click on view -> tools window -> contrast
<img width="503" alt="Screen Shot 2022-10-26 at 4 19 09 PM" src="https://user-images.githubusercontent.com/104797527/198129175-576eee75-c8c2-4768-ab24-133d0664c1fa.png">

- add your credentials
<img width="987" alt="Screen Shot 2022-10-26 at 4 19 24 PM" src="https://user-images.githubusercontent.com/104797527/198129237-69be6ab3-dabc-4508-9a5e-1d57d109f497.png">


- You should now see your orgs vulnerabilities 
- everything else with the plugin should work

### _Evidence_:
- <img width="1374" alt="Screen Shot 2022-10-26 at 4 19 41 PM" src="https://user-images.githubusercontent.com/104797527/198129307-28253a70-0f47-43dd-946b-5fb70ac2383f.png">
